### PR TITLE
login, onboard, and otp screen fixes

### DIFF
--- a/vimbisopay_app/.env.example
+++ b/vimbisopay_app/.env.example
@@ -1,8 +1,8 @@
 # API Configuration
 # Development environment
 DEV_API_KEY=your_development_api_key_here
-DEV_BASE_URL=https://dev.example.com
+DEV_BASE_URL=https://dev.mycredex.dev
 
 # Production environment
 PROD_API_KEY=your_production_api_key_here
-PROD_BASE_URL=https://example.com
+PROD_BASE_URL=https://mycredex.app

--- a/vimbisopay_app/lib/core/utils/phone_validator.dart
+++ b/vimbisopay_app/lib/core/utils/phone_validator.dart
@@ -6,11 +6,16 @@ class PhoneValidator {
     // Remove any non-digit characters before validation
     final String digitsOnly = value.replaceAll(RegExp(r'\D'), '');
     
+    // Validate country code and length
     if (!RegExp(r'^[0-9]{3}[0-9]+$').hasMatch(digitsOnly)) {
-      return 'Start with country code (e.g. 263 or 353)';
+      // Return an empty string instead of an error message
+      // This will still make the validation fail but won't show a message
+      return '';
     }
     if (digitsOnly.length < 10) {
-      return 'Phone number is too short';
+      // Return an empty string instead of an error message
+      // This will still make the validation fail but won't show a message
+      return '';
     }
     return null;
   }

--- a/vimbisopay_app/lib/core/utils/plain_phone_formatter.dart
+++ b/vimbisopay_app/lib/core/utils/plain_phone_formatter.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/services.dart';
+
+class PlainPhoneNumberFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    // Only allow digits
+    final String digitsOnly = newValue.text.replaceAll(RegExp(r'\D'), '');
+    
+    // No formatting, just return digits
+    return TextEditingValue(
+      text: digitsOnly,
+      selection: TextSelection.collapsed(offset: digitsOnly.length),
+    );
+  }
+}

--- a/vimbisopay_app/lib/presentation/screens/create_account_screen.dart
+++ b/vimbisopay_app/lib/presentation/screens/create_account_screen.dart
@@ -10,6 +10,7 @@ import 'package:vimbisopay_app/presentation/widgets/loading_dialog.dart' show Lo
 import 'package:vimbisopay_app/presentation/widgets/otp_verification_flow.dart';
 import 'package:vimbisopay_app/core/utils/phone_validator.dart';
 import 'package:vimbisopay_app/core/utils/phone_formatter.dart';
+import 'package:vimbisopay_app/core/utils/plain_phone_formatter.dart';
 import 'package:vimbisopay_app/core/theme/input_decoration_theme.dart';
 
 class CreateAccountScreen extends StatefulWidget {
@@ -29,7 +30,6 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
   final _repository = ServiceLocator.accountRepository;
   bool _isFormValid = false;
   bool _isLoading = false;
-  bool _acceptedTerms = false;
   bool _showPassword = false;
   bool _showConfirmPassword = false;
   final Map<String, String?> _fieldErrors = {
@@ -49,7 +49,9 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
   }
 
   String? _getFieldError(String fieldName) {
-    return _touchedFields.contains(fieldName) ? _fieldErrors[fieldName] : null;
+    // Only return non-empty error messages
+    final error = _touchedFields.contains(fieldName) ? _fieldErrors[fieldName] : null;
+    return (error != null && error.isNotEmpty) ? error : null;
   }
 
   @override
@@ -100,8 +102,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
           hasValidLastName &&
           hasValidPhone &&
           hasValidPassword &&
-          hasValidConfirmPassword &&
-          _acceptedTerms;
+          hasValidConfirmPassword;
           
       Logger.data('[CreateAccount] Form validation result: ${_isFormValid ? 'valid' : 'invalid'}');
       if (!_isFormValid) {
@@ -206,7 +207,9 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
     }
     
     try {
-      final phoneNumber = '+${_phoneController.text}';
+      // The phone number is already in the correct format (digits only)
+      // thanks to PlainPhoneNumberFormatter
+      final phoneNumber = _phoneController.text;
       final password = _passwordController.text;
       
       Logger.interaction('[CreateAccount] Starting account creation process');
@@ -509,14 +512,14 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                           child: TextFormField(
                             controller: _phoneController,
                             decoration: const InputDecoration(
-                              labelText: 'Phone Number',
+                              labelText: 'WhatsApp Number',
                               prefixIcon: Icon(Icons.phone),
-                              helperText: 'Start with country code (e.g. 263 for Zimbabwe, 353 for Ireland)',
+                              helperText: 'Start with country code (e.g. 263 for Zimbabwe, 353 for Ireland, 1 for USA/Canada)',
                               helperMaxLines: 2,
                             ),
                             keyboardType: TextInputType.phone,
                             inputFormatters: [
-                              PhoneNumberFormatter(),
+                              PlainPhoneNumberFormatter(),
                             ],
                             enabled: !_isLoading,
                             onTap: () => _markFieldAsTouched('phone'),
@@ -631,47 +634,6 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                           ),
                         ),
                         const SizedBox(height: 24),
-                        Row(
-                          children: [
-                            Checkbox(
-                              value: _acceptedTerms,
-                              onChanged: (value) {
-                                setState(() {
-                                  _acceptedTerms = value ?? false;
-                                  _validateForm();
-                                });
-                              },
-                              activeColor: AppColors.primary,
-                            ),
-                            Expanded(
-                              child: GestureDetector(
-                                onTap: () {
-                                  setState(() {
-                                    _acceptedTerms = !_acceptedTerms;
-                                    _validateForm();
-                                  });
-                                },
-                                child: const Text.rich(
-                                  TextSpan(
-                                    text: 'I agree to the ',
-                                    style: TextStyle(
-                                      color: AppColors.textSecondary,
-                                    ),
-                                    children: [
-                                      TextSpan(
-                                        text: 'Terms and Conditions',
-                                        style: TextStyle(
-                                          color: AppColors.primary,
-                                          decoration: TextDecoration.underline,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
                       ],
                     ),
                   ),

--- a/vimbisopay_app/lib/presentation/screens/forgot_password_screen.dart
+++ b/vimbisopay_app/lib/presentation/screens/forgot_password_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:vimbisopay_app/core/theme/app_colors.dart';
 import 'package:vimbisopay_app/core/utils/logger.dart';
 import 'package:vimbisopay_app/core/utils/phone_validator.dart';
-import 'package:vimbisopay_app/core/utils/phone_formatter.dart';
+import 'package:vimbisopay_app/core/utils/plain_phone_formatter.dart';
 import 'package:vimbisopay_app/core/theme/input_decoration_theme.dart';
 import 'package:vimbisopay_app/infrastructure/services/service_locator.dart';
 import 'package:vimbisopay_app/presentation/widgets/loading_dialog.dart';
@@ -36,7 +36,9 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   }
 
   String? _getFieldError(String fieldName) {
-    return _touchedFields.contains(fieldName) ? _fieldErrors[fieldName] : null;
+    // Only return non-empty error messages
+    final error = _touchedFields.contains(fieldName) ? _fieldErrors[fieldName] : null;
+    return (error != null && error.isNotEmpty) ? error : null;
   }
 
   @override
@@ -113,7 +115,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           ),
           SizedBox(height: 8),
           Text(
-            'Enter your phone number and we\'ll send you instructions to reset your password.',
+            'Enter your phone number and we\'ll send you a code on WhatsApp to reset your password.',
             style: TextStyle(
               fontSize: 14,
               color: AppColors.textPrimary,
@@ -220,17 +222,16 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
       builder: (context) {
         Logger.interaction('[ForgotPassword] Building loading dialog');
         return const LoadingDialog(
-          message: 'Sending instructions...',
+          message: 'Sending code...',
         );
       },
     ));
 
     try {
-      final phoneNumber = '+${_phoneController.text}';
-      final sanitizedPhone =
-          PhoneNumberFormatter.sanitizePhoneNumber(phoneNumber);
+      // The phone number is already in the correct format (digits only)
+      // thanks to PlainPhoneNumberFormatter
       final result = await _repository.requestOtp(
-        phone: sanitizedPhone,
+        phone: _phoneController.text,
         purpose: 'PASSWORD_RESET',
       );
 
@@ -263,7 +264,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           }
           Logger.data('[ForgotPassword] Got memberIdfrom response');
           // Show OTP verification dialog with memberId and token
-          _showOtpVerification(sanitizedPhone, memberId);
+          _showOtpVerification(_phoneController.text, memberId);
         },
       );
     } catch (e) {
@@ -317,12 +318,12 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                             labelText: 'Phone Number',
                             prefixIcon: Icon(Icons.phone),
                             helperText:
-                                'Start with country code (e.g. 263 for Zimbabwe, 353 for Ireland)',
+                                'Start with country code (e.g. 263 for Zimbabwe, 353 for Ireland, 1 for USA/Canada)',
                             helperMaxLines: 2,
                           ),
                           keyboardType: TextInputType.phone,
                           inputFormatters: [
-                            PhoneNumberFormatter(),
+                            PlainPhoneNumberFormatter(),
                           ],
                           enabled: !_isLoading,
                           onTap: () => _markFieldAsTouched('phone'),

--- a/vimbisopay_app/lib/presentation/screens/login_screen.dart
+++ b/vimbisopay_app/lib/presentation/screens/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:vimbisopay_app/core/utils/logger.dart';
 import 'package:vimbisopay_app/core/utils/password_validator.dart';
 import 'package:vimbisopay_app/core/utils/phone_validator.dart';
 import 'package:vimbisopay_app/core/utils/phone_formatter.dart';
+import 'package:vimbisopay_app/core/utils/plain_phone_formatter.dart';
 import 'package:vimbisopay_app/core/utils/screen_tracker.dart';
 import 'package:vimbisopay_app/core/utils/button_tracker.dart';
 import 'package:vimbisopay_app/core/theme/input_decoration_theme.dart';
@@ -52,7 +53,9 @@ class _LoginScreenState extends State<LoginScreen> with ScreenViewTrackerMixin {
   }
 
   String? _getFieldError(String fieldName) {
-    return _touchedFields.contains(fieldName) ? _fieldErrors[fieldName] : null;
+    // Only return non-empty error messages
+    final error = _touchedFields.contains(fieldName) ? _fieldErrors[fieldName] : null;
+    return (error != null && error.isNotEmpty) ? error : null;
   }
 
   @override
@@ -64,10 +67,8 @@ class _LoginScreenState extends State<LoginScreen> with ScreenViewTrackerMixin {
   Future<void> _loadSavedUser() async {
     final user = await _databaseHelper.getUser();
     if (user != null && mounted) {
-      // Remove the '+' prefix if it exists
-      final phoneNumber = user.phone.startsWith('+') 
-          ? user.phone.substring(1) 
-          : user.phone;
+      // Remove any non-digit characters
+      final phoneNumber = user.phone.replaceAll(RegExp(r'\D'), '');
       setState(() {
         _phoneController.text = phoneNumber;
       });
@@ -350,7 +351,9 @@ class _LoginScreenState extends State<LoginScreen> with ScreenViewTrackerMixin {
       },
     ));
 
-    final phoneNumber = '+${_phoneController.text}';
+    // The phone number is already in the correct format (digits only)
+    // thanks to PlainPhoneNumberFormatter
+    final phoneNumber = _phoneController.text;
     final password = _passwordController.text;
     
     Logger.interaction('[Login] Calling login API');
@@ -411,9 +414,8 @@ class _LoginScreenState extends State<LoginScreen> with ScreenViewTrackerMixin {
                 ),
               );
 
-              final sanitizedPhone = PhoneNumberFormatter.sanitizePhoneNumber(phoneNumber);
               final otpResult = await _repository.requestOtp(
-                phone: sanitizedPhone,
+                phone: phoneNumber,
                 purpose: 'PASSWORD_RESET',
               );
 
@@ -476,9 +478,8 @@ class _LoginScreenState extends State<LoginScreen> with ScreenViewTrackerMixin {
             ),
           );
 
-          final sanitizedPhone = PhoneNumberFormatter.sanitizePhoneNumber(phoneNumber);
           final otpResult = await _repository.requestOtp(
-            phone: sanitizedPhone,
+            phone: phoneNumber,
             purpose: 'PASSWORD_RESET',
           );
 
@@ -562,12 +563,12 @@ class _LoginScreenState extends State<LoginScreen> with ScreenViewTrackerMixin {
                           decoration: const InputDecoration(
                             labelText: 'Phone Number',
                             prefixIcon: Icon(Icons.phone),
-                            helperText: 'Start with country code (e.g. 263 for Zimbabwe, 353 for Ireland)',
+                            helperText: 'Start with country code (e.g. 263 for Zimbabwe, 353 for Ireland, 1 for USA/Canada)',
                             helperMaxLines: 2,
                           ),
                           keyboardType: TextInputType.phone,
                           inputFormatters: [
-                            PhoneNumberFormatter(),
+                            PlainPhoneNumberFormatter(),
                           ],
                           enabled: !_isLoading,
                           onTap: () => _markFieldAsTouched('phone'),

--- a/vimbisopay_app/lib/presentation/widgets/otp_verification_flow.dart
+++ b/vimbisopay_app/lib/presentation/widgets/otp_verification_flow.dart
@@ -273,6 +273,7 @@ class _OTPVerificationFlowState extends State<OTPVerificationFlow> {
   Widget build(BuildContext context) {
     return AlertDialog(
       backgroundColor: AppColors.surface,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 24.0),
       title: const Text(
         'Verify Phone Number',
         style: TextStyle(
@@ -296,60 +297,68 @@ class _OTPVerificationFlowState extends State<OTPVerificationFlow> {
                 ),
               ],
             )
-          : SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const Text(
-                    'Please enter the 6-digit code sent to your Whatsapp phone number to verify your account.',
-                    style: TextStyle(
-                      color: AppColors.textPrimary,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  if (_error != null)
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color: AppColors.error.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(8),
+          : ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: MediaQuery.of(context).size.width * 0.8,
+                maxHeight: MediaQuery.of(context).size.height * 0.7,
+              ),
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text(
+                      'Please enter the 6-digit code sent to your Whatsapp phone number to verify your account.',
+                      style: TextStyle(
+                        color: AppColors.textPrimary,
                       ),
-                      child: Text(
-                        _error!,
-                        style: const TextStyle(
-                          color: AppColors.error,
-                          fontSize: 14,
+                    ),
+                    const SizedBox(height: 16),
+                    if (_error != null)
+                      Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: AppColors.error.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          _error!,
+                          style: const TextStyle(
+                            color: AppColors.error,
+                            fontSize: 14,
+                          ),
+                          overflow: TextOverflow.visible,
+                          softWrap: true,
                         ),
                       ),
+                    const SizedBox(height: 16),
+                    TextField(
+                      controller: _otpController,
+                      decoration: const InputDecoration(
+                        labelText: 'Enter OTP',
+                        prefixIcon: Icon(Icons.lock_outline),
+                        helperText: 'Enter the 6-digit code',
+                      ),
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.digitsOnly,
+                        LengthLimitingTextInputFormatter(6),
+                      ],
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _verifyOTP(),
                     ),
-                  const SizedBox(height: 16),
-                  TextField(
-                    controller: _otpController,
-                    decoration: const InputDecoration(
-                      labelText: 'Enter OTP',
-                      prefixIcon: Icon(Icons.lock_outline),
-                      helperText: 'Enter the 6-digit code',
+                    const SizedBox(height: 16),
+                    TextButton(
+                      onPressed: _isResending ? null : _resendOTP,
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColors.primary,
+                      ),
+                      child: Text(
+                        _isResending ? 'Resending...' : 'Resend OTP',
+                      ),
                     ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                      LengthLimitingTextInputFormatter(6),
-                    ],
-                    textInputAction: TextInputAction.done,
-                    onSubmitted: (_) => _verifyOTP(),
-                  ),
-                  const SizedBox(height: 16),
-                  TextButton(
-                    onPressed: _isResending ? null : _resendOTP,
-                    style: TextButton.styleFrom(
-                      foregroundColor: AppColors.primary,
-                    ),
-                    child: Text(
-                      _isResending ? 'Resending...' : 'Resend OTP',
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
       actions: _isLoading
@@ -366,6 +375,12 @@ class _OTPVerificationFlowState extends State<OTPVerificationFlow> {
               ),
               TextButton(
                 onPressed: _verifyOTP,
+                style: ButtonStyle(
+                  minimumSize: MaterialStateProperty.all(const Size(80, 36)),
+                  padding: MaterialStateProperty.all(
+                    const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                ),
                 child: const Text(
                   'Verify',
                   style: TextStyle(


### PR DESCRIPTION
# Merge Summary: Phone Number Handling and UI Improvements

## Overview
This merge includes several changes to improve phone number handling, WhatsApp integration, and UI components across the onboard, login, and OTP screens. The changes focus on standardizing phone number input, improving error handling, and enhancing the user experience.

## env.example
- Updated development base URL from `https://dev.example.com` to `https://dev.mycredex.dev`
- Updated production base URL from `https://example.com` to `https://mycredex.app`

## Phone Number Handling
- **New Formatter**: Added `PlainPhoneNumberFormatter` that only allows digits without any special formatting
- **Silent Validation**: Modified phone validator to fail silently (returning empty strings instead of error messages)
- **Consistent Format**: Standardized phone number handling across all screens to use digits-only format
- **WhatsApp Integration**: Updated UI text to clarify that phone numbers are WhatsApp numbers and codes will be sent via WhatsApp

## UI/UX Improvements
- **Create Account Screen**:
  - Removed Terms and Conditions checkbox requirement
  - Changed phone field label to "WhatsApp Number"
  - Updated helper text to include USA/Canada country code example (1)
  
- **Forgot Password Screen**:
  - Updated messaging to specify that reset codes will be sent via WhatsApp
  - Improved error handling to only display non-empty error messages
  
- **Login Screen**:
  - Improved phone number handling as above
  - Enhanced error message display logic
  
- **OTP Verification Dialog**:
  - Improved layout constraints for better display on different screen sizes
  - Added proper text overflow handling for error messages
  - Enhanced button styling with better padding and minimum size
  - Added proper inset padding for the dialog

## Technical Details

### Phone Validation
Error messages were too aggressive so the phone validator now fails silently when validation rules aren't met

### Phone Formatting
Switched from the previous `PhoneNumberFormatter` to the new `PlainPhoneNumberFormatter` which:
- Only allows digits (removes all non-digit characters)
- Doesn't apply any special formatting (spaces, dashes, etc.)
- Simplifies backend integration by providing consistent digit-only phone numbers
- this integrates internationally, and is the format for default account handles that we want people to be accustomed to

## Files Changed
1. `vimbisopay_app/.env.example`
2. `vimbisopay_app/lib/core/utils/phone_validator.dart`
3. `vimbisopay_app/lib/core/utils/plain_phone_formatter.dart` (new file)
4. `vimbisopay_app/lib/presentation/screens/create_account_screen.dart`
5. `vimbisopay_app/lib/presentation/screens/forgot_password_screen.dart`
6. `vimbisopay_app/lib/presentation/screens/login_screen.dart`
7. `vimbisopay_app/lib/presentation/widgets/otp_verification_flow.dart`